### PR TITLE
adds createdAt and updatedAt fields 

### DIFF
--- a/modules/db.js
+++ b/modules/db.js
@@ -18,22 +18,7 @@ db.version(2).stores({
     '++id, name, price, isPurchased, section, quantityUnit, createdAt, updatedAt',
 });
 
-// These work - https://dexie.org/docs/Table/Table.hook('creating')
-// but we have another option available to us (see below)
-// dexie hooks to handle creation and update
-// db.items.hook('creating', (primKey, obj, trans) => {
-//   obj.createdAt = new Date().toISOString();
-//   obj.updatedAt = obj.createdAt;
-// });
-
-// db.items.hook('updating', (modifications, primKey, obj, trans) => {
-//   modifications.updatedAt = new Date().toISOString();
-//   return modifications;
-// });
-
-// set created and updated at times automatically based on triggers:
-
-// we have another option outside of the hooks available to us: https://dexie.org/docs/DBCore/DBCore
+// https://dexie.org/docs/DBCore/DBCore
 // define dbcore middleware
 const timestampsMiddleware = {
   stack: 'dbcore',
@@ -64,7 +49,7 @@ const timestampsMiddleware = {
                 });
               }
             }
-
+            // return the modified db core instance
             return downlevelTable.mutate(req);
           },
         };

--- a/modules/db.js
+++ b/modules/db.js
@@ -13,9 +13,67 @@ db.version(1).stores({
 // enum - pounds, ounces, units, box
 // createdAt - date
 // updatedAt - date
-// db.version(2).stores({
-//   items:
-//     '++id, name, price, isPurchased, section, quantityUnit, createdAt, updatedAt',
+db.version(2).stores({
+  items:
+    '++id, name, price, isPurchased, section, quantityUnit, createdAt, updatedAt',
+});
+
+// These work - https://dexie.org/docs/Table/Table.hook('creating')
+// but we have another option available to us (see below)
+// dexie hooks to handle creation and update
+// db.items.hook('creating', (primKey, obj, trans) => {
+//   obj.createdAt = new Date().toISOString();
+//   obj.updatedAt = obj.createdAt;
 // });
+
+// db.items.hook('updating', (modifications, primKey, obj, trans) => {
+//   modifications.updatedAt = new Date().toISOString();
+//   return modifications;
+// });
+
+// set created and updated at times automatically based on triggers:
+
+// we have another option outside of the hooks available to us: https://dexie.org/docs/DBCore/DBCore
+// define dbcore middleware
+const timestampsMiddleware = {
+  stack: 'dbcore',
+  name: 'timestampsMiddleware',
+  create: (downlevelDBCore) => {
+    return {
+      ...downlevelDBCore,
+      table: (tableName) => {
+        // retrieve the db table based on name
+        const downlevelTable = downlevelDBCore.table(tableName);
+
+        return {
+          ...downlevelTable,
+          // when mutating, determine if create/update
+          mutate: async (req) => {
+            if (tableName === 'items') {
+              const now = new Date().toISOString();
+
+              if (req.type === 'add') {
+                req.values.forEach((item) => {
+                  item.createdAt = now;
+                  item.updatedAt = now;
+                });
+              } else if (req.type === 'put') {
+                // only update the updatedAt on put req
+                req.values.forEach((item) => {
+                  item.updatedAt = now;
+                });
+              }
+            }
+
+            return downlevelTable.mutate(req);
+          },
+        };
+      },
+    };
+  },
+};
+
+// use our timestamp middlware
+db.use(timestampsMiddleware);
 
 export default db;

--- a/modules/form.js
+++ b/modules/form.js
@@ -50,6 +50,9 @@ itemForm.onsubmit = async (event) => {
   const quantity = document.getElementById('quantityInput').value;
   const price = document.getElementById('priceInput').value;
 
+  // now we need to add section (store section), quantityUnit
+  // and createdAt, updatedAt - can these be handled with dexie? Defaults?
+
   await db.items.add({ name, quantity, price });
   // refresh items div
   await populateItems();


### PR DESCRIPTION
These fields will be relevant when we begin building the Pantry portion of this project. 

In the pantry users can track the store items they currently have in their household, and if they wish to they can updated quantities and know when to add that item to the shopping list. 

We don't want to handle manually setting these when we create or update items so I initially used [Dexie hooks]() to build this functionality:

```js
db.items.hook('creating', (primKey, obj, trans) => {
   obj.createdAt = new Date().toISOString();
   obj.updatedAt = obj.createdAt;
 });

 db.items.hook('updating', (modifications, primKey, obj, trans) => {
   modifications.updatedAt = new Date().toISOString();
   return modifications;
});
```

This works, but the docs point out there's a more recent, and better suited [way to build middlewares with DBcore](https://dexie.org/docs/DBCore/DBCore) that we can use instead. 

This is a better solution because it aims to handle bulk add, put, and delete operations. 

Result after adding db core middleware in PR:

<img width="846" alt="image" src="https://github.com/user-attachments/assets/ae5c502a-1da3-4192-8984-02c43c586f2c">
