### PR TITLE
adds quantity unit

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,10 +63,36 @@
               <span class="error" id="nameError"></span>
             </label>
 
+            <div class="formInputGroup">
             <label for="quantityInput">
               Quantity
               <input type="number" id="quantityInput" value="1" />
             </label>
+
+            <label for="quantityUnitInput">
+              Unit 
+              <select name="quantityUnitInput" id="quantityUnitInput">
+                <option value="unit">unit</option>
+                <option value="ounces">ounces</option>
+                <option value="pounds">pounds</option>
+                <option value="grams">grams</option>
+                <option value="kilograms">kilograms</option>
+                
+                <option disabled>──────────</option>
+                <option value="milliliters">milliliters</option>
+                <option value="liters">liters</option>
+                <option value="pints">pints</option>
+                <option value="quarts">quarts</option>
+                <option value="gallons">gallons</option>
+                
+                <option disabled>──────────</option>
+                <option value="dozen">dozen</option>
+                <option value="pack">pack</option>
+                <option value="box">box</option>
+                <option value="bag">bag</option>
+              </select>
+            </label>
+            </div>
 
             <label for="priceInput">
               Price

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
             <label for="quantityUnitInput">
               Unit 
               <select name="quantityUnitInput" id="quantityUnitInput">
+                <option>select unit</option>
                 <option value="unit">unit</option>
                 <option value="ounces">ounces</option>
                 <option value="pounds">pounds</option>

--- a/modules/db.js
+++ b/modules/db.js
@@ -19,7 +19,8 @@ db.version(2).stores({
 });
 
 // https://dexie.org/docs/DBCore/DBCore
-// define dbcore middleware
+// when uploading backed up data, we'll need to figure out how to skip the actions in here, since we'll already have created and updated at
+// define dbcore middleware - if this grows a lot, we should add a middleware module
 const timestampsMiddleware = {
   stack: 'dbcore',
   name: 'timestampsMiddleware',

--- a/modules/form.js
+++ b/modules/form.js
@@ -48,12 +48,12 @@ itemForm.onsubmit = async (event) => {
 
   const name = document.getElementById('nameInput').value;
   const quantity = document.getElementById('quantityInput').value;
+  const quantityUnit = document.getElementById('quantityUnitInput').value;
   const price = document.getElementById('priceInput').value;
 
-  // now we need to add section (store section), quantityUnit
-  // and createdAt, updatedAt - can these be handled with dexie? Defaults?
+  // now we need to add section (store section)
 
-  await db.items.add({ name, quantity, price });
+  await db.items.add({ name, quantity, quantityUnit, price });
   // refresh items div
   await populateItems();
 

--- a/modules/populateItems.js
+++ b/modules/populateItems.js
@@ -55,7 +55,7 @@ export const populateItems = async () => {
             <p class="itemInfoHeading">Quantity</p>
             <p class="itemQuantityText" id="item-quantity-${item.id}">${
         item.quantity
-      }</p>
+      } ${item.quantityUnit}</p>
           </div>
           <div class="itemPriceContainer">
             <p class="itemInfoHeading">Est. Price</p>

--- a/styles/form.css
+++ b/styles/form.css
@@ -9,7 +9,8 @@
   font-size: 20px;
 }
 
-#itemForm input {
+#itemForm input,
+select {
   display: block;
   height: 2.5rem;
   font-size: 20px;
@@ -17,6 +18,12 @@
   border-radius: 8px;
   margin-top: 0.5rem;
   width: 100%;
+}
+
+.formInputGroup {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
 }
 
 #itemForm input:invalid {

--- a/styles/form.css
+++ b/styles/form.css
@@ -34,6 +34,10 @@ select {
   outline: 1px solid var(--nav-bg-color);
 }
 
+#itemForm select:focus-visible {
+  outline: 1px solid var(--nav-bg-color);
+}
+
 #quantityInput,
 #priceInput {
   width: 3rem;

--- a/styles/items.css
+++ b/styles/items.css
@@ -74,6 +74,7 @@
 
 .itemQuantityText {
   font-weight: 600;
+  font-size: 18px;
 }
 
 .itemPriceContainer {

--- a/styles/modal.css
+++ b/styles/modal.css
@@ -13,7 +13,8 @@
 .modal-content {
   background-color: #fefefe;
   margin: 15% auto;
-  padding: 20px;
+  padding: 2rem;
+  padding-bottom: 0.5rem;
   border: 1px solid #888;
   width: 90%;
   border-radius: 8px;


### PR DESCRIPTION
- Adds `quantityUnit` to the add item form - as a drop down menu next to the unit input 
- Displays the quantity unit in the populateItems return 
- Updates styles to support new display and select input 

<img width="389" alt="image" src="https://github.com/user-attachments/assets/3b7c004f-78b1-4eb4-b670-90a78543d34e">
<img width="389" alt="image" src="https://github.com/user-attachments/assets/9497561e-5ecf-4f5d-a1cc-0089e8f9c9a9">

I chose not tackle the custom quantity scenario - like "One 2.5 pound bag" of sugar 

I will tackle this in the future, but for now we're focused on MVP and keeping this all simple. Before I risk overcomplicating the tables we're creating, I should do more research on how to approach this. 
