### PR TITLE
feat: add quantity unit, created/updated at, section fields, inputs, and filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,25 +72,7 @@
             <label for="quantityUnitInput">
               Unit 
               <select name="quantityUnitInput" id="quantityUnitInput">
-                <option value="">select unit</option>
-                <option value="unit">unit</option>
-                <option value="ounces">ounces</option>
-                <option value="pounds">pounds</option>
-                <option value="grams">grams</option>
-                <option value="kilograms">kilograms</option>
-                
-                <option disabled>──────────</option>
-                <option value="milliliters">milliliters</option>
-                <option value="liters">liters</option>
-                <option value="pints">pints</option>
-                <option value="quarts">quarts</option>
-                <option value="gallons">gallons</option>
-                
-                <option disabled>──────────</option>
-                <option value="dozen">dozen</option>
-                <option value="pack">pack</option>
-                <option value="box">box</option>
-                <option value="bag">bag</option>
+                <!-- GENERATED IN FORM.JS AND OPTIONSDATA.JS -->
               </select>
             </label>
             </div>
@@ -111,26 +93,7 @@
             <label for="sectionInput">
               Store Section
               <select name="sectionInput" id="sectionInput">
-                <option value="">Select store section</option>
-                <option value="produce">Produce</option>
-                <option value="dairy">Dairy</option>
-                <option value="meat">Meat & Poultry</option>
-                <option value="seafood">Seafood</option>
-                <option value="deli">Deli</option>
-                <option value="bakery">Bakery</option>
-                <option value="frozen">Frozen Foods</option>
-                <option value="beverages">Beverages</option>
-                <option value="snacks">Snacks</option>
-                <option value="canned">Canned Goods</option>
-                <option value="dry-goods">Dry Goods & Pasta</option>
-                <option value="condiments">Condiments & Sauces</option>
-                <option value="baking">Baking Supplies</option>
-                <option value="spices">Spices & Seasonings</option>
-                <option value="breakfast">Breakfast Foods</option>
-                <option value="health-beauty">Health & Beauty</option>
-                <option value="household">Household Supplies</option>
-                <option value="pet">Pet Supplies</option>
-                <option value="ethnic">Ethnic Foods</option>
+                <!-- GENERATED IN FORM.JS AND OPTIONSDATA.JS -->
               </select>
             </label>
 
@@ -215,6 +178,7 @@
     <script type="module" src="./modules/populateItems.js"></script>
     <script type="module" src="./modules/modal.js"></script>
     <script type="module" src="./modules/optionsModal.js"></script>
+    <script type="module" src="./modules/optionsData.js"></script>
     <script type="module" src="./modules/form.js"></script>
     <script type="module" src="./modules/exportDb.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
             <label for="quantityUnitInput">
               Unit 
               <select name="quantityUnitInput" id="quantityUnitInput">
-                <option>select unit</option>
+                <option value="">select unit</option>
                 <option value="unit">unit</option>
                 <option value="ounces">ounces</option>
                 <option value="pounds">pounds</option>
@@ -98,13 +98,40 @@
             <label for="priceInput">
               Price
               <input
-                type="text"
                 id="priceInput"
+                type="number"
                 placeholder="1.99"
-                pattern="^\d+(\.\d{1,2})?$"
+                step="0.01"
+                min="0"
                 aria-describedby="priceError"
               />
               <span class="error" id="priceError"></span>
+            </label>
+
+            <label for="sectionInput">
+              Store Section
+              <select name="sectionInput" id="sectionInput">
+                <option value="">Select store section</option>
+                <option value="produce">Produce</option>
+                <option value="dairy">Dairy</option>
+                <option value="meat">Meat & Poultry</option>
+                <option value="seafood">Seafood</option>
+                <option value="deli">Deli</option>
+                <option value="bakery">Bakery</option>
+                <option value="frozen">Frozen Foods</option>
+                <option value="beverages">Beverages</option>
+                <option value="snacks">Snacks</option>
+                <option value="canned">Canned Goods</option>
+                <option value="dry-goods">Dry Goods & Pasta</option>
+                <option value="condiments">Condiments & Sauces</option>
+                <option value="baking">Baking Supplies</option>
+                <option value="spices">Spices & Seasonings</option>
+                <option value="breakfast">Breakfast Foods</option>
+                <option value="health-beauty">Health & Beauty</option>
+                <option value="household">Household Supplies</option>
+                <option value="pet">Pet Supplies</option>
+                <option value="ethnic">Ethnic Foods</option>
+              </select>
             </label>
 
             <div class="formActionsDiv">
@@ -146,6 +173,17 @@
         </p>
         <label class="switch">
           <input id="hideChecked" type="checkbox" class="switch-input">
+          <span class="switch-label" data-on="On" data-off="Off"></span>
+          <span class="switch-handle"></span>
+        </label>
+      </div>
+
+      <div class="filterControl">
+        <p class="controlText">
+          Sort by Section
+        </p>
+        <label class="switch">
+          <input id="sectionSort" type="checkbox" class="switch-input">
           <span class="switch-label" data-on="On" data-off="Off"></span>
           <span class="switch-handle"></span>
         </label>

--- a/index.html
+++ b/index.html
@@ -63,10 +63,37 @@
               <span class="error" id="nameError"></span>
             </label>
 
+            <div class="formInputGroup">
             <label for="quantityInput">
               Quantity
               <input type="number" id="quantityInput" value="1" />
             </label>
+
+            <label for="quantityUnitInput">
+              Unit 
+              <select name="quantityUnitInput" id="quantityUnitInput">
+                <option>select unit</option>
+                <option value="unit">unit</option>
+                <option value="ounces">ounces</option>
+                <option value="pounds">pounds</option>
+                <option value="grams">grams</option>
+                <option value="kilograms">kilograms</option>
+                
+                <option disabled>──────────</option>
+                <option value="milliliters">milliliters</option>
+                <option value="liters">liters</option>
+                <option value="pints">pints</option>
+                <option value="quarts">quarts</option>
+                <option value="gallons">gallons</option>
+                
+                <option disabled>──────────</option>
+                <option value="dozen">dozen</option>
+                <option value="pack">pack</option>
+                <option value="box">box</option>
+                <option value="bag">bag</option>
+              </select>
+            </label>
+            </div>
 
             <label for="priceInput">
               Price

--- a/modules/db.js
+++ b/modules/db.js
@@ -19,7 +19,8 @@ db.version(2).stores({
 });
 
 // https://dexie.org/docs/DBCore/DBCore
-// define dbcore middleware
+// when uploading backed up data, we'll need to figure out how to skip the actions in here, since we'll already have created and updated at
+// define dbcore middleware - if this grows a lot, we should add a middleware module
 const timestampsMiddleware = {
   stack: 'dbcore',
   name: 'timestampsMiddleware',

--- a/modules/domElements.js
+++ b/modules/domElements.js
@@ -17,3 +17,4 @@ export const toggleArrow = document.getElementById('arrow');
 // filter options
 export const autoSort = document.getElementById('autoSort');
 export const hideChecked = document.getElementById('hideChecked');
+export const sectionSort = document.getElementById('sectionSort');

--- a/modules/domElements.js
+++ b/modules/domElements.js
@@ -8,6 +8,8 @@ export const nameInput = document.getElementById('nameInput');
 export const nameError = document.getElementById('nameError');
 export const priceInput = document.getElementById('priceInput');
 export const priceError = document.getElementById('priceError');
+export const quantityUnitSelect = document.getElementById('quantityUnitInput');
+export const sectionSelect = document.getElementById('sectionInput');
 // show/hide filter ui
 export const showItemsControlContainer =
   document.getElementById('showItemsControl');

--- a/modules/form.js
+++ b/modules/form.js
@@ -63,11 +63,11 @@ itemForm.onsubmit = async (event) => {
 
   if (!valid) return;
 
-  const name = document.getElementById('nameInput').value;
+  const name = nameInput.value;
   const quantity = document.getElementById('quantityInput').value;
-  const quantityUnit = document.getElementById('quantityUnitInput').value;
-  const price = document.getElementById('priceInput').value;
-  const section = document.getElementById('sectionInput').value;
+  const quantityUnit = quantityUnitSelect.value;
+  const price = priceInput.value;
+  const section = sectionSelect.value;
 
   await db.items.add({ name, quantity, quantityUnit, price, section });
   // refresh items div

--- a/modules/form.js
+++ b/modules/form.js
@@ -50,6 +50,9 @@ itemForm.onsubmit = async (event) => {
   const quantity = document.getElementById('quantityInput').value;
   const price = document.getElementById('priceInput').value;
 
+  // now we need to add section (store section), quantityUnit
+  // and createdAt, updatedAt - can these be handled with dexie? Defaults?
+
   await db.items.add({ name, quantity, price });
   // refresh items div
   await populateItems();

--- a/modules/form.js
+++ b/modules/form.js
@@ -50,10 +50,9 @@ itemForm.onsubmit = async (event) => {
   const quantity = document.getElementById('quantityInput').value;
   const quantityUnit = document.getElementById('quantityUnitInput').value;
   const price = document.getElementById('priceInput').value;
+  const section = document.getElementById('sectionInput').value;
 
-  // now we need to add section (store section)
-
-  await db.items.add({ name, quantity, quantityUnit, price });
+  await db.items.add({ name, quantity, quantityUnit, price, section });
   // refresh items div
   await populateItems();
 

--- a/modules/form.js
+++ b/modules/form.js
@@ -48,12 +48,12 @@ itemForm.onsubmit = async (event) => {
 
   const name = document.getElementById('nameInput').value;
   const quantity = document.getElementById('quantityInput').value;
+  const quantityUnit = document.getElementById('quantityUnitInput').value;
   const price = document.getElementById('priceInput').value;
 
-  // now we need to add section (store section), quantityUnit
-  // and createdAt, updatedAt - can these be handled with dexie? Defaults?
+  // now we need to add section (store section)
 
-  await db.items.add({ name, quantity, price });
+  await db.items.add({ name, quantity, quantityUnit, price });
   // refresh items div
   await populateItems();
 

--- a/modules/form.js
+++ b/modules/form.js
@@ -5,8 +5,15 @@ import {
   nameError,
   priceInput,
   priceError,
+  quantityUnitSelect,
+  sectionSelect,
 } from './domElements.js';
 import { populateItems } from './populateItems.js';
+import {
+  storeSectionOptions,
+  quantityUnitsOptions,
+  createOptions,
+} from './optionsData.js';
 import db from './db.js';
 
 export const clearForm = () => {
@@ -25,6 +32,16 @@ export const clearPriceErrors = () => {
   priceInput.setCustomValidity('');
   priceError.textContent = '';
 };
+
+// generate the options in section and quantity unit selects
+document.addEventListener('DOMContentLoaded', () => {
+  if (quantityUnitSelect) {
+    quantityUnitSelect.innerHTML = createOptions(quantityUnitsOptions);
+  }
+  if (sectionSelect) {
+    sectionSelect.innerHTML = createOptions(storeSectionOptions);
+  }
+});
 
 // Form submit
 itemForm.onsubmit = async (event) => {

--- a/modules/optionsData.js
+++ b/modules/optionsData.js
@@ -1,0 +1,56 @@
+export const storeSectionOptions = [
+  { value: '', text: 'Select store section' },
+  { value: 'produce', text: 'Produce' },
+  { value: 'dairy', text: 'Dairy' },
+  { value: 'meat', text: 'Meat & Poultry' },
+  { value: 'seafood', text: 'Seafood' },
+  { value: 'deli', text: 'Deli' },
+  { value: 'bakery', text: 'Bakery' },
+  { value: 'frozen', text: 'Frozen Foods' },
+  { value: 'beverages', text: 'Beverages' },
+  { value: 'snacks', text: 'Snacks' },
+  { value: 'canned', text: 'Canned Goods' },
+  { value: 'dry-goods', text: 'Dry Goods & Pasta' },
+  { value: 'condiments', text: 'Condiments & Sauces' },
+  { value: 'baking', text: 'Baking Supplies' },
+  { value: 'spices', text: 'Spices & Seasonings' },
+  { value: 'breakfast', text: 'Breakfast Foods' },
+  { value: 'health-beauty', text: 'Health & Beauty' },
+  { value: 'household', text: 'Household Supplies' },
+  { value: 'pet', text: 'Pet Supplies' },
+  { value: 'ethnic', text: 'Ethnic Foods' },
+];
+
+export const quantityUnitsOptions = [
+  { value: '', text: 'select unit' },
+  { value: 'unit', text: 'unit' },
+  { value: 'ounces', text: 'ounces' },
+  { value: 'pounds', text: 'pounds' },
+  { value: 'grams', text: 'grams' },
+  { value: 'kilograms', text: 'kilograms' },
+  { value: 'separator' },
+  { value: 'milliliters', text: 'milliliters' },
+  { value: 'liters', text: 'liters' },
+  { value: 'pints', text: 'pints' },
+  { value: 'quarts', text: 'quarts' },
+  { value: 'gallons', text: 'gallons' },
+  { value: 'separator' },
+  { value: 'dozen', text: 'dozen' },
+  { value: 'pack', text: 'pack' },
+  { value: 'box', text: 'box' },
+  { value: 'bag', text: 'bag' },
+];
+
+/* Helper to create a list of `option` elements from the data above */
+export const createOptions = (optionsArray) => {
+  return optionsArray
+    .map((option) => {
+      // handle the seperators
+      if (option.value === 'separator') {
+        return '<option disabled>──────────</option>';
+      } else {
+        return `<option value="${option.value}">${option.text}</option>`;
+      }
+    })
+    .join('');
+};

--- a/modules/optionsModal.js
+++ b/modules/optionsModal.js
@@ -1,4 +1,4 @@
-import { autoSort, hideChecked } from './domElements.js';
+import { autoSort, hideChecked, sectionSort } from './domElements.js';
 import { populateItems } from './populateItems.js';
 
 // get modal and focusable elements
@@ -63,3 +63,4 @@ closeModalButton.addEventListener('click', hideOptionsModal);
 
 autoSort.addEventListener('change', populateItems);
 hideChecked.addEventListener('change', populateItems);
+sectionSort.addEventListener('change', populateItems);

--- a/modules/populateItems.js
+++ b/modules/populateItems.js
@@ -55,7 +55,7 @@ export const populateItems = async () => {
             <p class="itemInfoHeading">Quantity</p>
             <p class="itemQuantityText" id="item-quantity-${item.id}">${
         item.quantity
-      }</p>
+      } ${item.quantityUnit}</p>
           </div>
           <div class="itemPriceContainer">
             <p class="itemInfoHeading">Est. Price</p>

--- a/styles/form.css
+++ b/styles/form.css
@@ -9,7 +9,8 @@
   font-size: 20px;
 }
 
-#itemForm input {
+#itemForm input,
+select {
   display: block;
   height: 2.5rem;
   font-size: 20px;
@@ -19,11 +20,21 @@
   width: 100%;
 }
 
+.formInputGroup {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
 #itemForm input:invalid {
   outline: 1px solid var(--button-hover-bg-color);
 }
 
 #itemForm input:focus-visible {
+  outline: 1px solid var(--nav-bg-color);
+}
+
+#itemForm select:focus-visible {
   outline: 1px solid var(--nav-bg-color);
 }
 

--- a/styles/items.css
+++ b/styles/items.css
@@ -74,6 +74,7 @@
 
 .itemQuantityText {
   font-weight: 600;
+  font-size: 18px;
 }
 
 .itemPriceContainer {

--- a/styles/items.css
+++ b/styles/items.css
@@ -45,21 +45,21 @@
   padding-bottom: 0.2rem;
 }
 
-.itemInfo > div {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
 .itemInfoHeading {
   font-size: 14px;
   font-style: italic;
   letter-spacing: 0.05rem;
 }
 
+.storeSection {
+  text-align: right;
+}
+
 .itemNameContainer {
   grid-area: name;
   font-size: 22px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
 }
 
 .itemNameText {

--- a/styles/modal.css
+++ b/styles/modal.css
@@ -13,7 +13,8 @@
 .modal-content {
   background-color: #fefefe;
   margin: 15% auto;
-  padding: 20px;
+  padding: 2rem;
+  padding-bottom: 0.5rem;
   border: 1px solid #888;
   width: 90%;
   border-radius: 8px;


### PR DESCRIPTION
- Update db to support `section` `quantityUnit`, `createdAt`, `updatedAt` fields 
- Automatically populate and update `createdAt`/`updatedAt` fields 
- Add form input for `quantityUnit`
- Add form input for `section` - store section 
- Show the unit and store section on the list items - not sure how this will end up being redesigned, but for now just get it on the page 
- Add "filter by store section" settings option 

<img width="398" alt="image" src="https://github.com/user-attachments/assets/18a356ec-ecea-42aa-bc32-abef69662f24">
<img width="410" alt="image" src="https://github.com/user-attachments/assets/1723d6f4-2a2f-4761-a285-f53de2d45673">

