### PR TITLE
enhancement: accessibility on list items, filter options, and form dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
     <link rel="icon" href="./assets/icon-192.png" />
     <link rel="stylesheet" href="./index.css" />
     <link rel="stylesheet" href="./styles/nav.css" />
-    <link rel="stylesheet" href="./styles/modal.css" />
-    <link rel="stylesheet" href="./styles/optionsModal.css" />
-    <link rel="stylesheet" href="./styles/switch.css" />
-    <link rel="stylesheet" href="./styles/form.css" />
     <link rel="stylesheet" href="./styles/buttons.css" />
     <link rel="stylesheet" href="./styles/items.css" />
+    <link rel="stylesheet" href="./styles/modal.css" />
+    <link rel="stylesheet" href="./styles/form.css" />
+    <link rel="stylesheet" href="./styles/switch.css" />
+    <link rel="stylesheet" href="./styles/optionsModal.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="manifest" href="./manifest.json">
@@ -120,33 +120,33 @@
       <div class="filterInputs">
       
       <div class="filterControl">
-        <p class="controlText">
+        <p id="autoSortLabel" class="controlText">
           Auto Sort
         </p>
         <label class="switch">
-          <input id="autoSort" type="checkbox" class="switch-input">
+          <input name="autoSort" aria-labelledby="autoSortLabel" id="autoSort" type="checkbox" class="switch-input">
           <span class="switch-label" data-on="On" data-off="Off"></span>
           <span class="switch-handle"></span>
         </label>
       </div>
 
       <div class="filterControl">
-        <p class="controlText">
+        <p id="hideCheckedLabel" class="controlText">
           Hide Checked
         </p>
         <label class="switch">
-          <input id="hideChecked" type="checkbox" class="switch-input">
+          <input id="hideChecked" aria-labelledby="hideCheckedLabel" type="checkbox" class="switch-input">
           <span class="switch-label" data-on="On" data-off="Off"></span>
           <span class="switch-handle"></span>
         </label>
       </div>
 
       <div class="filterControl">
-        <p class="controlText">
+        <p id="sectionSortLabel" class="controlText">
           Sort by Section
         </p>
         <label class="switch">
-          <input id="sectionSort" type="checkbox" class="switch-input">
+          <input id="sectionSort" aria-labelledby="sectionSortLabel" type="checkbox" class="switch-input">
           <span class="switch-label" data-on="On" data-off="Off"></span>
           <span class="switch-handle"></span>
         </label>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
     </div>
 
     <!-- FILTERS AND OPTIONS SIDEBAR -->
-     <div id="optionsModal" class="optionsModal" role="dialog" aria-labelledby="optionsModalTitle" aria-modal="true" >
+     <div id="optionsModal" class="optionsModal" role="dialog" aria-labelledby="optionsModalTitle" aria-modal="true" aria-hidden="true" >
        
       <div class="optionsSettingsContainer">
         <div class="optionsModalTitleContainer">
@@ -161,7 +161,7 @@
      </div>
 
     <!-- SHOPPING ITEMS LIST -->
-    <div id="itemsDiv"></div>
+    <ul id="itemsDiv"></ul>
     <!-- TOTAL PRICE OF LIST -->
     <div class="stickyPriceFooter">
       <!-- ITEMS CONTROLS -->

--- a/modules/optionsData.js
+++ b/modules/optionsData.js
@@ -28,13 +28,13 @@ export const quantityUnitsOptions = [
   { value: 'pounds', text: 'pounds' },
   { value: 'grams', text: 'grams' },
   { value: 'kilograms', text: 'kilograms' },
-  { value: 'separator' },
+  { value: 'separator', text: '---------', disabled: true },
   { value: 'milliliters', text: 'milliliters' },
   { value: 'liters', text: 'liters' },
   { value: 'pints', text: 'pints' },
   { value: 'quarts', text: 'quarts' },
   { value: 'gallons', text: 'gallons' },
-  { value: 'separator' },
+  { value: 'separator', text: '---------', disabled: true },
   { value: 'dozen', text: 'dozen' },
   { value: 'pack', text: 'pack' },
   { value: 'box', text: 'box' },
@@ -47,7 +47,9 @@ export const createOptions = (optionsArray) => {
     .map((option) => {
       // handle the seperators
       if (option.value === 'separator') {
-        return '<option disabled>──────────</option>';
+        return `<option value="${option.value}" ${
+          option.disabled ? 'disabled' : ''
+        }>${option.text}</option>`;
       } else {
         return `<option value="${option.value}">${option.text}</option>`;
       }


### PR DESCRIPTION
Adds `aria` labels where appropriate:

- `select` input `options` are a little more safe for screen readers - we render a more appropriate separator option 
- `checkbox` inputs in the filter options (in the settings) get `aria-labelledby` their respective descriptive text 
- converts the `itemsDiv` to a `ul` - which is the appropriate parents for the `role='listitem'` shopping list items 
- Moved the needed updates to items to another ticket - something with the `grid` it's all in is stopping me from effectively adding some hidden (screen reader only) text to describe the intent of the checkbox - but the list items need to be more thoughtfully designed now that we have additional data we're rendering (store section, item quantity)

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/92061f8b-5c5a-421d-8daf-6d7ad4d21f8c">
