### PR TITLE
fix: remove the closed class from the footer when rendering items

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             <label for="sectionInput">
               Store Section
               <select name="sectionInput" id="sectionInput">
-                <!-- GENERATED IN FORM.JS AND OPTIONSDATA.JS -->
+                <!-- GENERATED IN FORM.TS AND OPTIONSDATA.JS -->
               </select>
             </label>
 
@@ -157,7 +157,7 @@
     <div class="stickyQuickSortFooter" id="stickyQuickSortFooter">
       <div id="quickSortWrapper">
       <div id="quickSortDiv">
-        <!-- CONTENT RENDERED IN POPULATEITEMS.JS -->
+        <!-- CONTENT RENDERED IN DOMUTILS.TS -->
       </div>
       </div>
     </div>

--- a/modules/domUtils.ts
+++ b/modules/domUtils.ts
@@ -67,11 +67,13 @@ export const renderSectionBubbles = (
   storeSectionData: any,
   selectedSection: string | null
 ) => {
-  if (!quickSortDiv) {
+  if (!quickSortDiv || !stickyQuickSortFooter) {
     console.error('Missing required DOM elements');
     return;
   }
-  console.log('render section bubbles', storeSectionData);
+
+  stickyQuickSortFooter.classList.remove('closed');
+
   quickSortDiv.innerHTML = Object.keys(storeSectionData)
     .sort()
     .map(


### PR DESCRIPTION
The `closed` class wasn't being removed when rendering the store section bubbles in `domUtils` - something I must have missed when implementing the `ItemManager` class. 

## Testing 

1. `npm run build`
2. `npm run dev`
3. Open project, clear browser cache, and add a new item to the list
4. The sticky footer with store section bubbles should appear as expected 