### PR TITLE
feat: adds basic landing page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pantry Pal</title>
+    <link rel="icon" href="./assets/icon-192.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="manifest" href="./manifest.json" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('./service-worker.js');
+        });
+      }
+    </script>
+  </head>
+  <body>
+    <nav>
+      <div class="navContents">
+        <p>Pantry Pal</p>
+      </div>
+    </nav>
+
+    <div class="landingContainer">
+      <div class="landingHero">
+        <h1>Keep track of what you need and what you have, in one place</h1>
+        <p>
+          Make meal management simpler, waste less food, and store go-to lists -
+          all in one place, without all the distractions
+        </p>
+      </div>
+      <div class="landingContent">
+        <h2 class="contentHeading">Simplify Meal Management</h2>
+        <p>
+          Fresh produce goes bad quickly, and it can be hard to keep track of
+          what's in the fride. With Pantry Pal you can add fresh grocery items
+          and get reminders to use them up.
+        </p>
+      </div>
+      <div class="landingContent">
+        <h2 class="contentHeading">Keep your data to yourself</h2>
+        <p>
+          Pantry Pal was built to use your device's storage, keeping the things
+          you buy and how often you buy them offline (and the app is available
+          offline too!), never sent to a database or outside service.
+        </p>
+      </div>
+      <div class="landingContent">
+        <h2 class="contentHeading">No distractions</h2>
+        <p>
+          Build lists without ads, and without suggestions based on other users'
+          buying habits. Putting a list in shopping mode simplifies things even
+          more, preventing accidental deletes, and keeping your eyes on the
+          prize.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import './styles/modal.css';
 import './styles/form.css';
 import './styles/switch.css';
 import './styles/optionsModal.css';
+import './styles/landing.css';
 import './modules/db';
 import './modules/domElements';
 import './modules/domUtils';

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -1,0 +1,20 @@
+.landingContainer {
+  padding-top: 4rem;
+}
+
+.landingHero {
+  background-color: var(--dark-grey);
+  padding: 10rem;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.landingContent {
+  padding-left: 8rem;
+  padding-right: 8rem;
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+  border-bottom: 1px solid gray;
+}

--- a/styles/optionsModal.css
+++ b/styles/optionsModal.css
@@ -3,7 +3,7 @@
   width: 0; /* TOGGLE SIZE IN JS */
   max-width: 300px;
   position: fixed;
-  z-index: 2;
+  z-index: 1001;
   top: 0;
   right: 0;
   bottom: 0;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -36,7 +36,12 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
+      filename: 'index.html',
       template: './index.html',
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'about.html',
+      template: './about.html',
     }),
     new CopyWebpackPlugin({
       patterns: [


### PR DESCRIPTION
Adds a basic landing page skeleton. 

I just added some basic styles, having it appear as index does, but without the settings selection in the nav. Basic 'marketing lingo' added, but will definitely be edited in the future when some SVG graphics/images/assets are added to make the whole page pop. 

For now I just added the page to the webpack config, but it's not directly linked anywhere, and there's no official routing set up. I may pursue setting up some SPA-like routing 🤔 