### PR TITLE
adds 'list' page 

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,22 +24,11 @@
     <nav>
       <div class="navContents">
         <p>Pantry Pal</p>
-        <button id="openOptionsModalButton">Settings</button>
       </div>
     </nav>
     <div class="container">
-      <!-- ADD LIST/ITEM MODAL TRIGGERS -->
+      <!-- ADD LIST MODAL TRIGGER -->
       <div class="openModalButtonContainer">
-        <button
-          class="openModalButton"
-          id="openModalButton"
-          aria-haspopup="dialog"
-          aria-controls="modal"
-        >
-          <div class="plus"></div>
-          <p>Add Item</p>
-        </button>
-
         <button
           class="openModalButton"
           id="openAddListModalButton"
@@ -51,79 +40,6 @@
         </button>
       </div>
 
-      <!-- MODAL STRUCTURE -->
-      <!-- ADD ITEM MODAL -->
-      <div
-        id="modal"
-        class="modal"
-        role="dialog"
-        aria-labelledby="modalTitle"
-        aria-modal="true"
-        aria-hidden="true"
-      >
-        <div class="modal-content">
-          <button id="closeModal" class="close" aria-label="Close">
-            &times;
-          </button>
-          <h2 id="modalTitle">Add New Item</h2>
-          <form id="addItemForm" novalidate>
-            <label for="nameInput">
-              Item
-              <input
-                type="text"
-                id="nameInput"
-                placeholder="Grocery Item"
-                aria-describedby="nameError"
-                required
-              />
-              <span class="error" id="nameError"></span>
-            </label>
-
-            <div class="formInputGroup">
-              <label for="quantityInput">
-                Quantity
-                <input type="number" id="quantityInput" value="1" />
-              </label>
-
-              <label for="quantityUnitInput">
-                Unit
-                <select name="quantityUnitInput" id="quantityUnitInput">
-                  <!-- GENERATED IN FORM.JS AND OPTIONSDATA.JS -->
-                </select>
-              </label>
-            </div>
-
-            <!-- <label for="priceInput">
-              Price
-              <input
-                id="priceInput"
-                type="number"
-                placeholder="1.99"
-                step="0.01"
-                min="0"
-                aria-describedby="priceError"
-              />
-              <span class="error" id="priceError"></span>
-            </label> -->
-
-            <label for="sectionInput">
-              Store Section
-              <select name="sectionInput" id="sectionInput">
-                <!-- GENERATED IN FORM.TS AND OPTIONSDATA.JS -->
-              </select>
-            </label>
-
-            <div class="formActionsDiv">
-              <button type="submit" class="addButton" id="addItemButton">
-                Add Item
-              </button>
-              <button id="cancelButton" class="cancelButton" type="button">
-                Cancel
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
       <!-- ADD LIST MODAL -->
       <div
         id="addListModal"
@@ -169,102 +85,13 @@
     </div>
 
     <!-- FILTERS AND OPTIONS SIDEBAR -->
-    <div
-      id="optionsModal"
-      class="optionsModal"
-      role="dialog"
-      aria-labelledby="optionsModalTitle"
-      aria-modal="true"
-      aria-hidden="true"
-    >
-      <div class="optionsSettingsContainer">
-        <div class="optionsModalTitleContainer">
-          <h2 class="optionsModalTitle">Settings</h2>
-          <button
-            id="closeOptionsModal"
-            class="close"
-            aria-label="Close Settings Panel"
-          >
-            &times;
-          </button>
-        </div>
+    <!-- TODO: We'll want something like the items filters for lists -->
 
-        <div class="filterInputs">
-          <div class="filterControl">
-            <p id="autoSortLabel" class="controlText">Auto Sort</p>
-            <label class="switch">
-              <input
-                name="autoSort"
-                aria-labelledby="autoSortLabel"
-                id="autoSort"
-                type="checkbox"
-                class="switch-input"
-              />
-              <span class="switch-label" data-on="On" data-off="Off"></span>
-              <span class="switch-handle"></span>
-            </label>
-          </div>
+    <!-- LISTS -->
+    <ul id="listsDiv">
+      <!-- RENDERED IN DOMUTILS  -->
+    </ul>
 
-          <div class="filterControl">
-            <p id="hideCheckedLabel" class="controlText">Hide Checked</p>
-            <label class="switch">
-              <input
-                id="hideChecked"
-                aria-labelledby="hideCheckedLabel"
-                type="checkbox"
-                class="switch-input"
-              />
-              <span class="switch-label" data-on="On" data-off="Off"></span>
-              <span class="switch-handle"></span>
-            </label>
-          </div>
-
-          <div class="filterControl">
-            <p id="sectionSortLabel" class="controlText">Sort by Section</p>
-            <label class="switch">
-              <input
-                id="sectionSort"
-                aria-labelledby="sectionSortLabel"
-                type="checkbox"
-                class="switch-input"
-              />
-              <span class="switch-label" data-on="On" data-off="Off"></span>
-              <span class="switch-handle"></span>
-            </label>
-          </div>
-        </div>
-
-        <div class="optionsModalFooter">
-          <button id="backupData" class="downloadDataButton">Download</button>
-
-          <div class="uploadBackupArea">
-            <form id="uploadBackupForm">
-              <label class="fileInputLabel" for="backupFileInput">
-                <input
-                  type="file"
-                  id="backupFileInput"
-                  accept="application/json"
-                />
-              </label>
-              <button class="uploadBackupButton" type="submit">Upload</button>
-              <!-- <div id="spinner">Loading...</div> -->
-            </form>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- SHOPPING ITEMS LIST -->
-    <ul id="itemsDiv"></ul>
-
-    <!-- SECTION SORTING -->
-    <div class="stickyQuickSortFooter" id="stickyQuickSortFooter">
-      <div id="quickSortWrapper">
-        <div id="quickSortDiv">
-          <!-- CONTENT RENDERED IN DOMUTILS.TS -->
-        </div>
-      </div>
-    </div>
     <script src="./index.js"></script>
   </body>
 </html>

--- a/list.html
+++ b/list.html
@@ -39,16 +39,6 @@
           <div class="plus"></div>
           <p>Add Item</p>
         </button>
-
-        <button
-          class="openModalButton"
-          id="openAddListModalButton"
-          aria-haspopup="dialog"
-          aria-controls="addListModal"
-        >
-          <div class="plus"></div>
-          <p>Add List</p>
-        </button>
       </div>
 
       <!-- MODAL STRUCTURE -->
@@ -118,48 +108,6 @@
                 Add Item
               </button>
               <button id="cancelButton" class="cancelButton" type="button">
-                Cancel
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-      <!-- ADD LIST MODAL -->
-      <div
-        id="addListModal"
-        class="listModal"
-        role="dialog"
-        aria-labelledby="addListModalTitle"
-        aria-modal="true"
-        aria-hidden="true"
-      >
-        <div class="addListModalContent">
-          <button id="closeListModal" class="close" aria-label="Close">
-            &times;
-          </button>
-          <h2 class="addListModalTitle">Add a List</h2>
-          <form id="addListForm" novalidate>
-            <label for="listNameInput">
-              Item
-              <input
-                type="text"
-                id="listNameInput"
-                placeholder="Taco Tuesday"
-                aria-describedby="listNameError"
-                required
-              />
-              <span class="error" id="listNameError"></span>
-            </label>
-
-            <div class="formActionsDiv">
-              <button type="submit" class="addButton" id="addListItemButton">
-                Add List
-              </button>
-              <button
-                id="cancelAddListButton"
-                class="cancelButton"
-                type="button"
-              >
                 Cancel
               </button>
             </div>
@@ -265,6 +213,6 @@
         </div>
       </div>
     </div>
-    <script src="./index.js"></script>
+    <script src="./list.js"></script>
   </body>
 </html>

--- a/modules/domUtils.ts
+++ b/modules/domUtils.ts
@@ -141,9 +141,11 @@ export const renderLists = (lists: List[]) => {
   listsDiv.innerHTML = lists
     .map(
       (list) => `
-        <div class="listSelection">
+      <a class="listLink" href="list.html?id=${list.id}">
+        <li class="listSelection">
           <h2>${list.name}</h2>
-        </div>
+        </li>
+        </a>
       `
     )
     .join('');

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -1,37 +1,26 @@
 import '../index.css';
 import '../styles/nav.css';
 import '../styles/buttons.css';
-import '../styles/items.css';
 import '../styles/lists.css';
 import '../styles/modal.css';
 import '../styles/form.css';
-import '../styles/switch.css';
-import '../styles/optionsModal.css';
 import '../styles/landing.css';
 import './db';
 import './domElements';
 import './domUtils';
-import './addItemform';
-import './uploadBackupForm';
-import './modal.js';
-import './optionsData.js';
-import './optionsModal';
 import './addListModal';
 import './addListForm';
 
-import { itemManager } from './itemManager';
-import { exportDb } from './exportDb';
+import { listManager } from './ListManager';
 
-window.toggleItemPurchaseStatus =
-  itemManager.toggleItemPurchaseStatus.bind(itemManager);
-window.removeItem = itemManager.removeItem.bind(itemManager);
-window.populateItems = itemManager.populateItems.bind(itemManager);
+// window.toggleItemPurchaseStatus =
+//   itemManager.toggleItemPurchaseStatus.bind(itemManager);
+// window.removeItem = itemManager.removeItem.bind(itemManager);
+// window.populateItems = itemManager.populateItems.bind(itemManager);
+window.populateLists = listManager.populateLists.bind(listManager);
 
 // get download button and add action
-const downloadButton = document.getElementById('backupData');
-downloadButton?.addEventListener('click', exportDb);
+// const downloadButton = document.getElementById('backupData');
+// downloadButton?.addEventListener('click', exportDb);
 
-// call populate to load shopping list items
-window.onload = window.populateItems;
-
-// This should actually be the /list page JS
+window.onload = window.populateLists;

--- a/modules/list.ts
+++ b/modules/list.ts
@@ -1,0 +1,33 @@
+import '../index.css';
+import '../styles/nav.css';
+import '../styles/buttons.css';
+import '../styles/items.css';
+import '../styles/lists.css';
+import '../styles/modal.css';
+import '../styles/form.css';
+import '../styles/switch.css';
+import '../styles/optionsModal.css';
+import '../styles/landing.css';
+import './db';
+import './domElements';
+import './domUtils';
+import './addItemform';
+import './uploadBackupForm';
+import './modal.js';
+import './optionsData.js';
+import './optionsModal';
+
+import { itemManager } from './itemManager';
+import { exportDb } from './exportDb';
+
+window.toggleItemPurchaseStatus =
+  itemManager.toggleItemPurchaseStatus.bind(itemManager);
+window.removeItem = itemManager.removeItem.bind(itemManager);
+window.populateItems = itemManager.populateItems.bind(itemManager);
+
+// get download button and add action
+const downloadButton = document.getElementById('backupData');
+downloadButton?.addEventListener('click', exportDb);
+
+// call populate to load shopping list items
+window.onload = window.populateItems;

--- a/styles/buttons.css
+++ b/styles/buttons.css
@@ -19,6 +19,7 @@
 }
 
 button {
+  cursor: pointer;
   border: none;
   border-radius: 8px;
   color: var(--button-text-color);

--- a/styles/lists.css
+++ b/styles/lists.css
@@ -1,6 +1,24 @@
 #listsDiv {
+  padding-left: 6rem;
+  padding-right: 6rem;
+  list-style-type: none;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-bottom: 20rem; /* spacing so items dont get lost under sticky footer*/
+}
+
+.listSelection {
+  box-shadow: var(--button-shadow);
+  border-radius: 8px;
+  padding: 1rem;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+  cursor: pointer;
+  font-family: var(--heading-font-family);
+  background: white;
+  color: var(--text-color);
+}
+
+.listLink {
+  text-decoration: none;
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,10 +5,10 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 module.exports = {
   entry: {
     index: './modules/index.ts', // Existing entry for index.html
-    // list: './modules/list.ts', // TODO: entry for List.html
+    list: './modules/list.ts', //
   },
   output: {
-    filename: '[name].js', // [name] placeholder will generate index.js and list.js
+    filename: '[name].js', // [name] placeholder will generate index.js and list.js - https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, 'dist'),
   },
   resolve: {
@@ -41,12 +41,17 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: './index.html',
-      chunks: ['index'], // Only include index.js in index.html
+      chunks: ['index'],
     }),
     new HtmlWebpackPlugin({
       filename: 'about.html',
       template: './about.html',
       chunks: ['index'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'list.html',
+      template: './list.html',
+      chunks: ['list'],
     }),
     new CopyWebpackPlugin({
       patterns: [


### PR DESCRIPTION
- Reworks the index page, simplifying content here to feature shopping lists 
- Moves single list and items renders to the list page 
- Updates `common` webpack config to bundle different JS chunks per page - index -> index, list -> list 

Next blocks of work (branched off this branch): 

[ ] Refactor list page and list.ts - fetch from `listItems` table, get `id` from URL 
[ ] Restore service worker for list page - this doesn't work right now with our dynamic routing, may need to reconsider the routing approach 
[ ] Refactor upload/download code for list -> list items setup
[ ] Update `ItemManager` class - `addItem` method needs to know which list we're adding an item to