### PR TITLE
feat: add items to lists

### DIFF
--- a/list.html
+++ b/list.html
@@ -28,6 +28,9 @@
       </div>
     </nav>
     <div class="container">
+      <div class="returnLinkContainer">
+        <a class="returnLink" href="/index">&larr; Return to lists</a>
+      </div>
       <!-- ADD LIST/ITEM MODAL TRIGGERS -->
       <div class="openModalButtonContainer">
         <button

--- a/modules/ListManager.ts
+++ b/modules/ListManager.ts
@@ -32,67 +32,6 @@ class ListManager {
     await db.lists.add({ name });
     await this.populateLists();
   }
-
-  // function to get the items that belong to a given list
-  // we need the list id, a num
-  async getListItems(id: string) {
-    // get the list from the db
-    const list = db.lists.get(parseInt(id));
-
-    if (!list) return console.error('No matching list found');
-
-    // get the items associated with the list from the join and items tables
-    // this is just a collection of items with an itemId and a listId
-    const listItems = db.itemLists
-      .where('listId')
-      .equals(parseInt(id))
-      .toArray();
-  }
 }
 
 export const listManager = new ListManager();
-
-// import { db } from './db';
-
-// document.addEventListener('DOMContentLoaded', () => {
-//   const urlParams = new URLSearchParams(window.location.search);
-//   const listId = urlParams.get('id');
-//   const listContainer = document.getElementById('itemsDiv');
-
-//   if (listId) {
-//     // Query the database for the list with the matching id
-//     db.lists.get(parseInt(listId)).then((list) => {
-//       if (list) {
-//         document.title = `${list.name} - Pantry Pal`; // Update the page title based on the list name
-
-//         // Fetch the items associated with this list
-//         db.itemLists
-//           .where('listId')
-//           .equals(parseInt(listId))
-//           .toArray()
-//           .then((itemLists) => {
-//             if (itemLists.length > 0) {
-//               const itemIds = itemLists.map((itemList) => itemList.itemId);
-//               db.items
-//                 .where('id')
-//                 .anyOf(itemIds)
-//                 .toArray()
-//                 .then((items) => {
-//                   // Render items in the DOM
-//                   const itemsHTML = items
-//                     .map((item) => `<li>${item.name} - $${item.price}</li>`)
-//                     .join('');
-//                   listContainer.innerHTML = `<ul>${itemsHTML}</ul>`;
-//                 });
-//             } else {
-//               listContainer.innerHTML = '<p>No items in this list.</p>';
-//             }
-//           });
-//       } else {
-//         listContainer.innerHTML = '<h1>List not found</h1>';
-//       }
-//     });
-//   } else {
-//     listContainer.innerHTML = '<h1>No list selected</h1>';
-//   }
-// });

--- a/modules/ListManager.ts
+++ b/modules/ListManager.ts
@@ -35,9 +35,6 @@ class ListManager {
 
   async fetchList(id: number) {
     const list = await db.lists.where('id').equals(id).toArray();
-
-    console.log('fetch lists, list: ', list);
-
     if (!list.length) return noListMessage();
   }
 }

--- a/modules/ListManager.ts
+++ b/modules/ListManager.ts
@@ -32,6 +32,67 @@ class ListManager {
     await db.lists.add({ name });
     await this.populateLists();
   }
+
+  // function to get the items that belong to a given list
+  // we need the list id, a num
+  async getListItems(id: string) {
+    // get the list from the db
+    const list = db.lists.get(parseInt(id));
+
+    if (!list) return console.error('No matching list found');
+
+    // get the items associated with the list from the join and items tables
+    // this is just a collection of items with an itemId and a listId
+    const listItems = db.itemLists
+      .where('listId')
+      .equals(parseInt(id))
+      .toArray();
+  }
 }
 
 export const listManager = new ListManager();
+
+// import { db } from './db';
+
+// document.addEventListener('DOMContentLoaded', () => {
+//   const urlParams = new URLSearchParams(window.location.search);
+//   const listId = urlParams.get('id');
+//   const listContainer = document.getElementById('itemsDiv');
+
+//   if (listId) {
+//     // Query the database for the list with the matching id
+//     db.lists.get(parseInt(listId)).then((list) => {
+//       if (list) {
+//         document.title = `${list.name} - Pantry Pal`; // Update the page title based on the list name
+
+//         // Fetch the items associated with this list
+//         db.itemLists
+//           .where('listId')
+//           .equals(parseInt(listId))
+//           .toArray()
+//           .then((itemLists) => {
+//             if (itemLists.length > 0) {
+//               const itemIds = itemLists.map((itemList) => itemList.itemId);
+//               db.items
+//                 .where('id')
+//                 .anyOf(itemIds)
+//                 .toArray()
+//                 .then((items) => {
+//                   // Render items in the DOM
+//                   const itemsHTML = items
+//                     .map((item) => `<li>${item.name} - $${item.price}</li>`)
+//                     .join('');
+//                   listContainer.innerHTML = `<ul>${itemsHTML}</ul>`;
+//                 });
+//             } else {
+//               listContainer.innerHTML = '<p>No items in this list.</p>';
+//             }
+//           });
+//       } else {
+//         listContainer.innerHTML = '<h1>List not found</h1>';
+//       }
+//     });
+//   } else {
+//     listContainer.innerHTML = '<h1>No list selected</h1>';
+//   }
+// });

--- a/modules/ListManager.ts
+++ b/modules/ListManager.ts
@@ -1,5 +1,5 @@
 import db, { List } from './db';
-import { renderLists } from './domUtils';
+import { renderLists, noListMessage } from './domUtils';
 
 class ListManager {
   selectedListId: number | null;
@@ -31,6 +31,14 @@ class ListManager {
     console.log('calling add list');
     await db.lists.add({ name });
     await this.populateLists();
+  }
+
+  async fetchList(id: number) {
+    const list = await db.lists.where('id').equals(id).toArray();
+
+    console.log('fetch lists, list: ', list);
+
+    if (!list.length) return noListMessage();
   }
 }
 

--- a/modules/addItemform.ts
+++ b/modules/addItemform.ts
@@ -16,6 +16,10 @@ import {
   createOptions,
 } from './optionsData.js';
 
+// get the URL search param -> ?=LIST_ID
+const urlSearchParams = new URLSearchParams(window.location.search);
+const currentListId = urlSearchParams.get('id');
+
 export const clearForm = () => {
   clearNameErrors();
   // clearPriceErrors();

--- a/modules/addListForm.ts
+++ b/modules/addListForm.ts
@@ -5,6 +5,7 @@ import {
   listNameError,
 } from './domElements';
 import { listManager } from './ListManager';
+import { hideAddFormModal } from './addListModal';
 
 export const clearForm = () => {
   clearNameErrors();
@@ -41,7 +42,7 @@ addListForm.onsubmit = async (event) => {
   await listManager.addList(name);
 
   addListForm?.reset();
-  listNameInput?.focus();
+  hideAddFormModal();
 };
 
 clearListFormButton?.addEventListener('click', clearForm);

--- a/modules/domUtils.ts
+++ b/modules/domUtils.ts
@@ -129,6 +129,21 @@ export const noItemsMessage = () => {
   stickyQuickSortFooter.classList.add('closed');
 };
 
+export const noListMessage = () => {
+  if (!itemsDiv || !stickyQuickSortFooter) {
+    console.error('Missing required DOM elements');
+    return;
+  }
+
+  itemsDiv.innerHTML = `
+    <div class="noItemsMessage">
+      <p>A list with this ID does not exist, or may have been removed.</p>
+      <p>Please return to the <a href="/index">Dashboard</a>.</p>
+    </div>
+  `;
+  stickyQuickSortFooter.classList.add('closed');
+};
+
 /* ------------------------------- LISTS SETUP ------------------------------ */
 // probably want to better name this module, and split based on items/lists
 

--- a/modules/itemManager.ts
+++ b/modules/itemManager.ts
@@ -18,18 +18,21 @@ type StoreSectionData = {
 //TODO: we could consider further breaking this down, by adding an ItemsService for db interactions
 class ItemManager {
   selectedSection: string | null;
+  currentListId: number | null;
 
   constructor() {
     this.selectedSection = null;
+    this.currentListId = null;
   }
 
   setSelectedSection(section: string | null) {
     this.selectedSection = section;
   }
 
-  private async fetchItems(): Promise<Item[]> {
-    return await db.items.reverse().toArray();
+  setListId(listId: number | null) {
+    this.currentListId = listId;
   }
+
   /** filter items by selected store section or if user has 'hide checked' turned on from options */
   private filterItems = (items: Item[], hideChecked: any) => {
     let filteredItems = items;
@@ -102,8 +105,54 @@ class ItemManager {
   };
 
   /** Populate the list items in the main view, and the Section bubbles footer */
+  // async populateItems() {
+  //   const allListItems = await this.fetchItems();
+
+  //   if (!allListItems.length) {
+  //     noItemsMessage();
+  //     return;
+  //   }
+
+  //   let sortedItems = this.filterItems(allListItems, hideChecked);
+
+  //   // arrange items based on auto sort or section sort
+  //   if (sectionSort && sectionSort.checked) {
+  //     sortedItems = this.sortItemsBySection(sortedItems);
+  //     // if section sort and auto sort is also turned on
+  //     if (autoSort && autoSort.checked) {
+  //       sortedItems = this.sortItemsByPurchaseStatus(sortedItems);
+  //     }
+  //   } else if (autoSort && autoSort.checked) {
+  //     sortedItems = this.sortItemsByPurchaseStatus(sortedItems);
+  //   }
+
+  //   const storeSectionsAndCounts = await this.generateStoreSectionData(
+  //     allListItems
+  //   );
+
+  //   renderItemsList(sortedItems);
+  //   renderSectionBubbles(storeSectionsAndCounts, this.selectedSection);
+  // }
+
+  /** Populate items in a specific list */
   async populateItems() {
-    const allListItems = await this.fetchItems();
+    // in reality this function should be able to take 2 paths - drilled down for the list, or for ALL items
+    // which we might support viewing? I'm not sure what the use case would be...
+    const listId = this.currentListId;
+    if (!listId) return;
+
+    // query the join tables for items data
+    const listItems = await db.itemLists
+      .where('listId')
+      .equals(listId)
+      .toArray();
+    const itemIds = listItems.map((item) => item.itemId);
+
+    const allListItems = await db.items
+      .where('id')
+      .anyOf(itemIds)
+      .reverse()
+      .toArray();
 
     if (!allListItems.length) {
       noItemsMessage();
@@ -131,6 +180,7 @@ class ItemManager {
     renderSectionBubbles(storeSectionsAndCounts, this.selectedSection);
   }
 
+  /** Add an item with/without a list */
   async addItem(
     name: string,
     quantity: number,
@@ -138,11 +188,23 @@ class ItemManager {
     price: number = 0,
     section: string
   ) {
-    await db.items.add({ name, quantity, quantityUnit, price, section });
+    const itemId = await db.items.add({
+      name,
+      quantity,
+      quantityUnit,
+      price,
+      section,
+    });
+    const listId = this.currentListId;
+    // add to the join table
+    if (listId) await db.itemLists.add({ itemId, listId });
+
     await this.populateItems();
   }
 
   async removeItem(id: number) {
+    // resetting selected section if we remove the last item in a section
+    // prevents user getting stuck in a selected section w/ no items
     if (this.selectedSection) {
       const itemToRm = await db.items.get(id);
       const isOtherSection =
@@ -160,6 +222,9 @@ class ItemManager {
     }
 
     await db.items.delete(id);
+    // remove from the join table if it exists
+    await db.itemLists.where('itemId').equals(id).delete();
+
     await this.populateItems();
   }
   /** Mark an item as 'in cart' //TODO: update from 'purchased' to 'in cart' */

--- a/modules/itemManager.ts
+++ b/modules/itemManager.ts
@@ -3,6 +3,7 @@ import {
   renderItemsList,
   renderSectionBubbles,
   noItemsMessage,
+  noListMessage,
 } from './domUtils';
 import { autoSort, hideChecked, sectionSort } from './domElements';
 
@@ -140,6 +141,11 @@ class ItemManager {
     // which we might support viewing? I'm not sure what the use case would be...
     const listId = this.currentListId;
     if (!listId) return;
+    const list = await db.lists.where('id').equals(listId).toArray();
+
+    console.log('fetch lists, list: ', list);
+
+    if (!list.length) return noListMessage();
 
     // query the join tables for items data
     const listItems = await db.itemLists

--- a/modules/itemManager.ts
+++ b/modules/itemManager.ts
@@ -105,36 +105,6 @@ class ItemManager {
     this.populateItems();
   };
 
-  /** Populate the list items in the main view, and the Section bubbles footer */
-  // async populateItems() {
-  //   const allListItems = await this.fetchItems();
-
-  //   if (!allListItems.length) {
-  //     noItemsMessage();
-  //     return;
-  //   }
-
-  //   let sortedItems = this.filterItems(allListItems, hideChecked);
-
-  //   // arrange items based on auto sort or section sort
-  //   if (sectionSort && sectionSort.checked) {
-  //     sortedItems = this.sortItemsBySection(sortedItems);
-  //     // if section sort and auto sort is also turned on
-  //     if (autoSort && autoSort.checked) {
-  //       sortedItems = this.sortItemsByPurchaseStatus(sortedItems);
-  //     }
-  //   } else if (autoSort && autoSort.checked) {
-  //     sortedItems = this.sortItemsByPurchaseStatus(sortedItems);
-  //   }
-
-  //   const storeSectionsAndCounts = await this.generateStoreSectionData(
-  //     allListItems
-  //   );
-
-  //   renderItemsList(sortedItems);
-  //   renderSectionBubbles(storeSectionsAndCounts, this.selectedSection);
-  // }
-
   /** Populate items in a specific list */
   async populateItems() {
     // in reality this function should be able to take 2 paths - drilled down for the list, or for ALL items

--- a/modules/list.ts
+++ b/modules/list.ts
@@ -20,6 +20,18 @@ import './optionsModal';
 import { itemManager } from './itemManager';
 import { exportDb } from './exportDb';
 
+// get the URL search param -> ?=LIST_ID
+const urlSearchParams = new URLSearchParams(window.location.search);
+const currentListId = urlSearchParams.get('id');
+
+// Set the listId in the ItemManager as local state - easier to avoid passing around an arg
+if (currentListId) {
+  itemManager.setListId(parseInt(currentListId, 10));
+} else {
+  // If no listId is present, set it to null to handle all items
+  itemManager.setListId(null);
+}
+
 window.toggleItemPurchaseStatus =
   itemManager.toggleItemPurchaseStatus.bind(itemManager);
 window.removeItem = itemManager.removeItem.bind(itemManager);

--- a/modules/list.ts
+++ b/modules/list.ts
@@ -27,10 +27,6 @@ const currentListId = urlSearchParams.get('id');
 
 // Set the listId in the ItemManager as local state - easier to avoid passing around an arg
 if (currentListId) {
-  // check if the list id is a valid list id
-  const test = listManager.fetchList(parseInt(currentListId, 10));
-  console.log('TEST: ', test);
-  // set ItemManager class state
   itemManager.setListId(parseInt(currentListId, 10));
 } else {
   // If no listId is present, set it to null to handle all items

--- a/modules/list.ts
+++ b/modules/list.ts
@@ -18,6 +18,7 @@ import './optionsData.js';
 import './optionsModal';
 
 import { itemManager } from './itemManager';
+import { listManager } from './ListManager';
 import { exportDb } from './exportDb';
 
 // get the URL search param -> ?=LIST_ID
@@ -26,6 +27,10 @@ const currentListId = urlSearchParams.get('id');
 
 // Set the listId in the ItemManager as local state - easier to avoid passing around an arg
 if (currentListId) {
+  // check if the list id is a valid list id
+  const test = listManager.fetchList(parseInt(currentListId, 10));
+  console.log('TEST: ', test);
+  // set ItemManager class state
   itemManager.setListId(parseInt(currentListId, 10));
 } else {
   // If no listId is present, set it to null to handle all items

--- a/styles/buttons.css
+++ b/styles/buttons.css
@@ -12,6 +12,11 @@
   gap: 1rem;
 }
 
+.returnLinkContainer {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
 @media (max-width: 600px) {
   .openModalButtonContainer {
     flex-direction: column;

--- a/styles/items.css
+++ b/styles/items.css
@@ -1,5 +1,7 @@
 .noItemsMessage {
   display: flex;
+  padding-left: 1rem;
+  padding-right: 1rem;
   flex-direction: column;
   align-items: center;
   gap: 1rem;


### PR DESCRIPTION
- Updates the `ItemManager` class to query for items in a more nuanced way, with the layer of a list on top
- Adds `currentListId` local state to the `ItemManager` class - a value we set only on the `/list` page 
- Updates `addItem` method - adding itemId and listId to the `itemList` join table when appropriate 
- Updates `populateItems` to populate items that belong to the current list 

Still a work in progress, we need to make sure -

[ ] Filtering still works, which it should 🤔
[ ] What happens when we navigate to a /list page with an id that doesn't exist in the database (we should send back to the base route? that's my first thought)
[ ] When we create a new list.... should we automatically go to that /list page? 