### PR TITLE
fix: use crypto api to generate uuid string ids

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,8 +1,8 @@
 declare global {
   interface Window {
     handleSectionClick: (event: Event, section: any) => void;
-    toggleItemPurchaseStatus: (event: Event, id: number) => Promise<void>;
-    removeItem: (id: number) => Promise<void>;
+    toggleItemPurchaseStatus: (event: Event, id: string) => Promise<void>;
+    removeItem: (id: string) => Promise<void>;
     populateItems: () => Promise<void>;
     populateLists: () => Promise<void>;
   }

--- a/list.html
+++ b/list.html
@@ -29,7 +29,7 @@
     </nav>
     <div class="container">
       <div class="returnLinkContainer">
-        <a class="returnLink" href="/index">&larr; Return to lists</a>
+        <a class="returnLink" href="index.html">&larr; Return to lists</a>
       </div>
       <!-- ADD LIST/ITEM MODAL TRIGGERS -->
       <div class="openModalButtonContainer">

--- a/modules/ListManager.ts
+++ b/modules/ListManager.ts
@@ -2,13 +2,13 @@ import db, { List } from './db';
 import { renderLists, noListMessage } from './domUtils';
 
 class ListManager {
-  selectedListId: number | null;
+  selectedListId: string | null;
 
   constructor() {
     this.selectedListId = null;
   }
 
-  setSelectedListId(id: number | null) {
+  setSelectedListId(id: string | null) {
     this.selectedListId = id;
   }
 
@@ -28,12 +28,15 @@ class ListManager {
   }
 
   async addList(name: string) {
-    console.log('calling add list');
-    await db.lists.add({ name });
+    const listId = crypto.randomUUID();
+    await db.lists.add({
+      id: listId,
+      name,
+    });
     await this.populateLists();
   }
 
-  async fetchList(id: number) {
+  async fetchList(id: string) {
     const list = await db.lists.where('id').equals(id).toArray();
     if (!list.length) return noListMessage();
   }

--- a/modules/domUtils.ts
+++ b/modules/domUtils.ts
@@ -24,7 +24,7 @@ export const renderItemsList = (items: Item[]) => {
            type="checkbox" 
            id="checkbox-${item.id}"
            class="checkbox" 
-           onchange="toggleItemPurchaseStatus(event, ${item.id})"
+           onchange="toggleItemPurchaseStatus(event, '${item.id}')"
            ${item.isPurchased ? 'checked' : ''}
            aria-labelledby="item-name-${item.id}"
            />
@@ -45,7 +45,7 @@ export const renderItemsList = (items: Item[]) => {
 
         <div class="itemActions">
         <button
-        onclick="removeItem(${item.id})"
+        onclick="removeItem('${item.id}')"
         class="deleteButton"
         aria-label="Remove ${item.name}"
         >

--- a/modules/list.ts
+++ b/modules/list.ts
@@ -27,7 +27,7 @@ const currentListId = urlSearchParams.get('id');
 
 // Set the listId in the ItemManager as local state - easier to avoid passing around an arg
 if (currentListId) {
-  itemManager.setListId(parseInt(currentListId, 10));
+  itemManager.setListId(currentListId);
 } else {
   // If no listId is present, set it to null to handle all items
   itemManager.setListId(null);


### PR DESCRIPTION
- Uses web crypto api to generate string ids for all db items 

### Testing 

1. `npm run build` 
2. `npm run dev` 
3. Clear site cache if needed 
4. Add a list 
5. Click the list 
6. Add an item to the list
7. Toggle purchase status
8. Remove the item 
9. Everything should work as before 