### PR TITLE
feat: introduce editing modal, restore list uploads, cleanup

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,3 +1,5 @@
+import { Item } from 'modules/db';
+
 declare global {
   interface Window {
     handleSectionClick: (event: Event, section: any) => void;
@@ -6,6 +8,7 @@ declare global {
     removeItem: (id: string) => Promise<void>;
     populateItems: () => Promise<void>;
     populateLists: () => Promise<void>;
+    openEditModal: (item: Item) => void;
   }
 }
 

--- a/modules/ItemManager/DatabaseService.ts
+++ b/modules/ItemManager/DatabaseService.ts
@@ -10,6 +10,17 @@ class DatabaseService {
     }
   }
 
+  //? Should this take a list id and update that as well? The ITEM and items table is not concerned with a list id so I'm gonna say no for now
+  async editItem(item: Item) {
+    const itemId = item.id;
+    if (!itemId) return console.warn('This item is missing an id');
+    const dbItem = await db.items.where('id').equals(itemId);
+    if (!dbItem)
+      return console.warn('No item with this id exists in the items table');
+
+    await db.items.update(itemId, item);
+  }
+
   async removeItem(id: string) {
     await db.items.delete(id);
     await db.itemLists.where('itemId').equals(id).delete();

--- a/modules/domUtils.ts
+++ b/modules/domUtils.ts
@@ -1,10 +1,12 @@
 import { Item, List } from './db';
 import {
+  addItemForm,
   itemsDiv,
   listsDiv,
   stickyQuickSortFooter,
   quickSortDiv,
 } from './domElements';
+import { openEditModal } from './addItemform';
 import itemManager from './ItemManager';
 
 export const renderItemsList = (items: Item[]) => {
@@ -55,6 +57,7 @@ export const renderItemsList = (items: Item[]) => {
         <button
         class="editButton"
         aria-label="Edit ${item.name}"
+        data-item-id="${item.id}"
         >
         Edit
         </button>
@@ -64,6 +67,31 @@ export const renderItemsList = (items: Item[]) => {
     `
     )
     .join('');
+
+  document.querySelectorAll('.editButton').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const target = event.target as HTMLElement; // Typecast to HTMLElement
+      const itemId = target.getAttribute('data-item-id');
+
+      const item = items.find((item) => item.id === itemId);
+      console.log(item);
+      if (!item) return console.warn('No item found');
+      if (!addItemForm) return console.warn('No add item form element');
+
+      // DEBUG: Whenever i call something from addItemForm in here I get:
+      // addItemform.ts:44 Uncaught TypeError: Cannot set properties of null (setting 'onsubmit')
+      // order of import thing? race condition? how to handle? IDFK, that's tomorrow Ash's problem
+
+      // openEditModal(item);
+      // if (itemId) {
+      //   const item = items.find((i) => i.id === itemId); // Find the item by id
+      //   if (item) {
+      //     openEditModal(item); // Pass the item to the edit modal
+      //   }
+      // }
+    });
+  });
 };
 
 export const renderSectionBubbles = (
@@ -105,6 +133,7 @@ export const renderSectionBubbles = (
 const handleSectionClick = (event: Event, section: string) => {
   event.preventDefault();
   itemManager.filterBySection(section);
+  itemManager.populateItems();
 };
 
 window.handleSectionClick = handleSectionClick;

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -10,17 +10,7 @@ import './domElements';
 import './domUtils';
 import './modals/addList';
 import './addListForm';
-
 import { listManager } from './ListManager';
 
-// window.toggleItemPurchaseStatus =
-//   itemManager.toggleItemPurchaseStatus.bind(itemManager);
-// window.removeItem = itemManager.removeItem.bind(itemManager);
-// window.populateItems = itemManager.populateItems.bind(itemManager);
 window.populateLists = listManager.populateLists.bind(listManager);
-
-// get download button and add action
-// const downloadButton = document.getElementById('backupData');
-// downloadButton?.addEventListener('click', exportDb);
-
 window.onload = window.populateLists;

--- a/modules/list.ts
+++ b/modules/list.ts
@@ -11,14 +11,13 @@ import '../styles/landing.css';
 import './db';
 import './domElements';
 import './domUtils';
-import './addItemform';
 import './uploadBackupForm';
 import './modals/addItem';
+import './addItemform';
 import './optionsData.js';
 import './modals/options';
 import './modals/confirmDelete';
 
-// import itemManager from './ItemManager';
 import itemManager from './ItemManager';
 import { listManager } from './ListManager';
 import { exportDb } from './exportDb';

--- a/modules/modals/confirmDelete.ts
+++ b/modules/modals/confirmDelete.ts
@@ -18,5 +18,6 @@ cancelTrigger?.addEventListener('click', () => {
 
 confirmTrigger?.addEventListener('click', () => {
   itemManager.removePurchasedItems();
+  itemManager.populateItems();
   confirmDeleteModalManager?.hideModal();
 });

--- a/modules/uploadBackupForm.ts
+++ b/modules/uploadBackupForm.ts
@@ -14,6 +14,7 @@ uploadBackupForm.onsubmit = async (event) => {
     try {
       await itemManager.syncUpload(file);
       alert('Upload complete!');
+      await itemManager.populateItems();
     } catch (err) {
       console.error('Error uploading file:', err);
       alert('There was a problem uploading your file, please try again');


### PR DESCRIPTION
- Introduces editing modal, linked to "edit" button on list items 
- Restore list uploads on the /list pages 
- Cleans up some comments and old code 
- Removes usage of `this.populateItems` from other inner methods on the ItemsManager class, instead `populateItems` is invoked by the called after the primary method has completed

This PR is in draft because I need to debug an issue with the editing modal not opening as expected - I'm not entirely sure on the reason, but I am currently looking into it, with a suspicions that it could be linked to an order of imports within my JS and the way it's being bundled, or a race condition with getting the item information from indexDB. It's further complicated because I tried to initially reuse the `addItemForm` - simply pre-populating it with item data fetched as needed. Making a separate but identical form could be easier - or at least help me understand what the problem is here. 

## Testing 

1. build and run - `npm run build && run dev`
2. Clear cache as needed
3. Create a list 
4. Upload a previously downloaded json list 
5. Items should add to the list
6. Mark as in cart, remove, etc items 
7. Everything should work as before 